### PR TITLE
Refactoring how '--installed-kernel' find kimg

### DIFF
--- a/virtme/commands/run.py
+++ b/virtme/commands/run.py
@@ -125,9 +125,22 @@ def find_kernel_and_mods(arch, args):
         modfiles = modfinder.find_modules_from_install(
             virtmods.MODALIASES, kver=kver)
         moddir = os.path.join('/lib/modules', kver)
-        kimg = '/usr/lib/modules/%s/vmlinuz' % kver
-        if not os.path.exists(kimg):
-            kimg = '/boot/vmlinuz-%s' % kver
+
+        kimg = None
+        kimg_paths = [
+            '/usr/lib/modules/%s/vmlinuz' % kver,
+            '/boot/vmlinuz-%s' % kver,
+            '/boot/vmlinuz-linux'
+        ]
+
+        for path in kimg_paths:
+            if os.path.exists(path):
+                kimg = path
+                break
+
+        if not kimg:
+            raise Exception("No kernel image found")
+
         dtb = None  # For now
     elif args.kdir is not None:
         kimg = os.path.join(args.kdir, arch.kimg_path())


### PR DESCRIPTION
Me and @dodys were having problems using `./virtme-run --installed-kernel` on Arch Linux. Arch doesn't create new `vmlinuz-` files for every new kernel installed, like others distros. In fact, Arch just rewrites the same `vmlinuz-linux` in all updates. So we came into this solution.

I created a list of known kernel paths to look for, so it's easy to add new ones if needed. If none of this options work, it's raises an exception.

Please let me know about any issue/improvements I can do to my code :)

Edit: recommited, now properly signed 